### PR TITLE
Check if the config file exist.

### DIFF
--- a/pastefile.py
+++ b/pastefile.py
@@ -23,6 +23,10 @@ parser.add_argument("-c", "--config", help="specify config file, default: %s"
 
 args = parser.parse_args()
 
+if not os.path.isfile(args.config):
+    print 'Error: config file %s not found' % args.config
+    exit(1)
+
 config = ConfigParser.ConfigParser()
 config.read(args.config)
 


### PR DESCRIPTION
Pastefile actually can't work without config file.
Check if the file exist to avoid this kind of error :

```
./pastefile.py
Traceback (most recent call last):
  File "./pastefile.py", line 36, in <module>
    hdl_file = logging.FileHandler(filename=app.config['log'])
KeyError: 'log'
```
