### PR TITLE
[bug] Fix 2 lock issues if db file does not exist.

### DIFF
--- a/jsondb.py
+++ b/jsondb.py
@@ -32,9 +32,11 @@ class JsonDB(object):
 
     def _lock(self):
         self._start = int(time.time())
+        # Open the file for lock only. If the file does not exist,
+        # it will be created
+        self._f = open(self._dbfile, 'a')
         while True:
             try:
-                self._f = open(self._dbfile, 'r+')
                 fcntl.flock(self._f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 self.load()
                 return True


### PR DESCRIPTION
Issue 1 :

the openfile is in the while. So we open the file and never close it each loop

```
In [4]: f = open('/etc/foo', 'r')

In [5]: id(f)
Out[5]: 140571115440864

In [6]: f = open('/etc/foo', 'r')

In [7]: id(f)
Out[7]: 140571115441008
```

Issue 2 :

The `open` used in the same try than the `flock`. Unfortunately, both raise the same Exception.
In case the file does not exist we never know and pastefile simply timeout on the lock.
