### PR TITLE
Tests: improve tests

### DIFF
--- a/pastefile/tests/test_functional.py
+++ b/pastefile/tests/test_functional.py
@@ -2,6 +2,7 @@
 
 
 import os
+from os.path import join as osjoin
 import unittest
 import json
 from StringIO import StringIO
@@ -14,16 +15,20 @@ import pastefile.app as flaskr
 
 class FlaskrTestCase(unittest.TestCase):
 
+    def clean_dir(self):
+        if os.path.isdir(self.testdir):
+            shutil.rmtree(self.testdir)
+
     def setUp(self):
+        self.testdir = './tests'
         flaskr.app.config['TESTING'] = True
-        if os.path.isdir('./tests'):
-            shutil.rmtree('./tests')
-        os.makedirs('./tests/files')
-        os.makedirs('./tests/tmp')
+        self.clean_dir()
+        os.makedirs(osjoin(self.testdir, 'files'))
+        os.makedirs(osjoin(self.testdir, 'tmp'))
         self.app = flaskr.app.test_client()
 
     def tearDown(self):
-        pass
+        self.clean_dir()
 
     def test_slash(self):
         rv = self.app.get('/', headers={'User-Agent': 'curl'})
@@ -36,10 +41,10 @@ class FlaskrTestCase(unittest.TestCase):
 
     def test_upload_and_retrieve(self):
         rnd_str = os.urandom(1024)
-        with open('./tests/test_file', 'w+') as f:
+        with open(osjoin(self.testdir, 'test_file'), 'w+') as f:
             f.writelines(rnd_str)
-        test_md5 = flaskr.get_md5('./tests/test_file')
-        with open('./tests/test_file', 'r') as f:
+        test_md5 = flaskr.get_md5(osjoin(self.testdir, 'test_file'))
+        with open(osjoin(self.testdir, 'test_file'), 'r') as f:
             rv = self.app.post('/', data={'file': (f, 'test_pastefile_random.file'),})
         assert rv.data == "http://localhost/%s\n" % (test_md5)
         assert rv.status == '200 OK'


### PR DESCRIPTION
- Add `clean_dir` function to clean tests directory before and after a test. (don't let file on disk after running test)
- Use variable for test directory instead of static name `self.testdir = './tests'`
- Add more tests in `test_ls` to validate when you have at least one file in pastefile. And also if you disable `/ls` url
