### PR TITLE
fix #45 Change Ls behavior when file have no info

### DIFF
--- a/pastefile/app.py
+++ b/pastefile/app.py
@@ -85,7 +85,9 @@ def clean_files(file_list):
 
 def infos_file(id_file, env=None):
     infos = get_infos_file_from_md5(id_file)
-    if infos:
+    if not infos:
+       return False
+    try:
         file_infos = {
             'name': infos['real_name'],
             'md5': id_file,
@@ -99,7 +101,9 @@ def infos_file(id_file, env=None):
             'url': "%s/%s" % (build_base_url(env=env), id_file)
         }
         return file_infos
-    return False
+    except:
+        LOG.error('Unable to gather infos for file %s' % id_file)
+        return False
 
 
 @app.route('/', methods=['GET', 'POST'])
@@ -228,7 +232,7 @@ def ls():
         instant_db = db.db
     for k, v in instant_db.iteritems():
         if not infos_file(k, env=request.environ):
-            return abort(500)
+            continue
         files_list_infos[k] = infos_file(k, env=request.environ)
     return jsonify(files_list_infos)
 

--- a/pastefile/tests/test_functional.py
+++ b/pastefile/tests/test_functional.py
@@ -1,16 +1,15 @@
 #!/usr/bin/python
 
-
 import os
 from os.path import join as osjoin
 import unittest
 import json
-from StringIO import StringIO
 import shutil
 os.environ['PASTEFILE_SETTINGS'] = '../pastefile-test.cfg'
 os.environ['TESTING'] = 'TRUE'
 
 import pastefile.app as flaskr
+from pastefile.tests.tools import write_random_file
 
 
 class FlaskrTestCase(unittest.TestCase):
@@ -41,11 +40,9 @@ class FlaskrTestCase(unittest.TestCase):
         self.assertEquals(json.loads(rv.data), {})
 
         # With one posted file
-        rnd_str = os.urandom(1024)
-        with open(osjoin(self.testdir, 'test_file'), 'w+') as f:
-            f.writelines(rnd_str)
-            f.seek(0)
-            rv = self.app.post('/', data={'file': (f, 'test_pastefile_random.file'),})
+        _file = osjoin(self.testdir, 'test_file')
+        last_file_md5 = write_random_file(_file) # keep md5 for next test
+        rv = self.app.post('/', data={'file': (open(_file, 'r'), 'test_pastefile_random.file'),})
         rv = self.app.get('/ls', headers={'User-Agent': 'curl'})
         self.assertEquals('200 OK', rv.status)
         # basic check if we have an array like {md5: {name: ...}}
@@ -53,13 +50,10 @@ class FlaskrTestCase(unittest.TestCase):
         self.assertEquals(['test_pastefile_random.file'], filenames)
 
         # Add one new file. Remove the first file from disk only in the last test
-        last_test_result = json.loads(rv.data).keys()
-        os.remove(osjoin(flaskr.app.config['UPLOAD_FOLDER'], last_test_result.pop()))
-        rnd_str = os.urandom(1024)
-        with open(osjoin(self.testdir, 'test_file_2'), 'w+') as f:
-            f.writelines(rnd_str)
-            f.seek(0)
-            rv = self.app.post('/', data={'file': (f, 'test_pastefile2_random.file'),})
+        os.remove(osjoin(flaskr.app.config['UPLOAD_FOLDER'], last_file_md5))
+        _file = osjoin(self.testdir, 'test_file_2')
+        write_random_file(_file)
+        rv = self.app.post('/', data={'file': (open(_file, 'r'), 'test_pastefile2_random.file'),})
         rv = self.app.get('/ls', headers={'User-Agent': 'curl'})
         filenames = [infos['name'] for md5, infos in json.loads(rv.data).iteritems()]
         self.assertEquals(['test_pastefile2_random.file'], filenames)

--- a/pastefile/tests/tools.py
+++ b/pastefile/tests/tools.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python
+
+import os
+import pastefile.app as flaskr
+
+
+def write_random_file(filename):
+    "Write file with a random content and return the md5"
+    rnd_str = os.urandom(1024)
+    with open(filename, 'w+') as f:
+        f.writelines(rnd_str)
+    return flaskr.get_md5(filename)


### PR DESCRIPTION
With tests.

Also fix an issue in infos_file when a file in db are not present on disk.

Without this patch, if a file is not present on disk, ls function will return a trace.

Is a file is not on disk and present in db, this is handled by clean_file
https://github.com/guits/pastefile/blob/master/pastefile/app.py#L78-L81

It's just a question of time to delete this entry in the db. `ls` should not fail
because of that.

Also add : Tests: add tools.py file and write_random_file function
Add tests/tools.py for function we use in functional test.
