### PR TITLE
jsondb.py: Open file not close if we can't acquire the lock.

### DIFF
--- a/pastefile/controller.py
+++ b/pastefile/controller.py
@@ -65,19 +65,19 @@ def get_file_info(id_file, config, env=None):
 
 def add_new_file(filename, source, dest, db, md5, burn_after_read):
 
-    # If no lock, return false
-    if db.lock_error:
-        return False
-
     # IMPROVE : possible "bug" If a file is already uploaded, the burn_after_read
     #           Will not bu updated
-    # File already exist, return True
+    # File already exist, return True and remove ths source
     if md5 in db.db:
         try:
             os.remove(source)
         except OSError as e:
             LOG.error("Can't remove tmp file: %s" % e)
         return True
+
+    # If no lock, return false
+    if db.lock_error:
+        return False
 
     try:
         os.rename(source, dest)

--- a/pastefile/jsondb.py
+++ b/pastefile/jsondb.py
@@ -50,6 +50,7 @@ class JsonDB(object):
                 if timeout(timeout=self._timeout, start=self._start):
                     self.lock_error = True
                     self._logger.critical('Unable to lock')
+                    self._f.close()
                     break
 
     def _release(self):

--- a/pastefile/jsondb.py
+++ b/pastefile/jsondb.py
@@ -22,7 +22,8 @@ class JsonDB(object):
         self.lock_error = False
 
     def __enter__(self):
-        self._lock()
+        if not self._lock():
+            self.lock_error = True
         self.load()
         return self
 
@@ -39,8 +40,7 @@ class JsonDB(object):
             self._f = open(self._dbfile, 'a')
         except IOError as e:
             self._logger.error('Error opening db file: %s' % e)
-            self.lock_error = True
-            return None
+            return False
         while True:
             try:
                 fcntl.flock(self._f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -48,10 +48,9 @@ class JsonDB(object):
             except IOError:
                 time.sleep(0.01)
                 if timeout(timeout=self._timeout, start=self._start):
-                    self.lock_error = True
                     self._logger.critical('Unable to lock')
                     self._f.close()
-                    break
+                    return False
 
     def _release(self):
         self._f.close()


### PR DESCRIPTION
- jsondb.py: Open file not close if we can't acquire the lock.
- Refact jsondb to simplify unittest and reading
- Improve add_new_file to return True if the file is already in db. No need to lock the db in that case
