### PR TITLE
jsondb :  [Errno 18] Invalid cross-device link

### DIFF
--- a/pastefile/jsondb.py
+++ b/pastefile/jsondb.py
@@ -4,7 +4,6 @@ import json
 import logging
 import fcntl
 import time
-import tempfile
 import os
 
 
@@ -66,11 +65,9 @@ class JsonDB(object):
 
     def save(self):
         try:
-            fd, tmp_file = tempfile.mkstemp(prefix='jsondb-',
-                                            dir=self._tmp_dir)
-            json.dump(self.db, os.fdopen(fd, 'w'))
+            tmp_file = '%s.atomic' % self._dbfile
+            json.dump(self.db, open(tmp_file, 'w'))
             os.rename(tmp_file, self._dbfile)
-
         except OSError as e:
             self._logger.error('Error while saving the db: %s' % e)
 


### PR DESCRIPTION
I was facing `Error while saving the db: [Errno 18] Invalid cross-device link`

Reading docs, it was simply related to the `os.rename` for the json db atomic save.

For the atomic save, we create a tmp file in `/tmp/`.

In my case `/tmp` is not on the same file system as pastefile (home) :

```
/dev/sda1           19G     16G  2,3G  87% /
/dev/mapper/home    99G     74G   25G  75% /home
```

So 2 solution :
- Use shutils.move
- Change the path of the tmpfile

Reading that :

```
As has been noted in comments on other answers, shutil.move simply calls os.rename in most cases. However, if the destination is on a different disk than the source, it will instead copy and then delete the source file.
```

I choose to take second option. Change the tmpfile path to ensure the atomic save is done each time on the same filesystem.
In case not the save is not very atomic and can impact preformances :p
