### PR TITLE
Fix broken functional tests : log file not found

### DIFF
--- a/pastefile-test.cfg
+++ b/pastefile-test.cfg
@@ -3,7 +3,7 @@ FILE_LIST = "./tests/uploaded_files_jsondb"
 TMP_FOLDER = "./tests/tmp"
 EXPIRE = 86400
 DEBUG_PORT = 5000
-LOG = "./tests/pastefile.log"
+LOG = "./pastefile/tests/pastefile.log"
 # Disable or not /ls url
 DISABLED_FEATURE = []
 DISPLAY_FOR = ['chrome', 'firefox']


### PR DESCRIPTION
Functional tests not working due to log file not found since commit dca6ee9b9bf0457dabf2afd5028365eb08964ee3
