### PR TITLE
dockerfile: Add file max size and display nginx logs on stdout

### DIFF
--- a/extra/Docker/configs/nginx.conf.template
+++ b/extra/Docker/configs/nginx.conf.template
@@ -12,7 +12,8 @@ http {
                       '$status $body_bytes_sent "$http_referer" '
                       '"$http_user_agent" "$http_x_forwarded_for"';
 
-    access_log  /var/log/nginx/access.log  main;
+    access_log  /dev/stdout  main;
+    error_log /dev/stdout info;
 
     sendfile            on;
     tcp_nopush          on;

--- a/extra/Docker/configs/vhost.conf.template
+++ b/extra/Docker/configs/vhost.conf.template
@@ -1,6 +1,7 @@
 server {
         listen ${NGINX_DEFAULT_PORT} default_server;
 
+        client_max_body_size ${MAX_FILE_SIZE};
 
         location / { try_files $uri @${NGINX_APP_NAME}; }
 

--- a/extra/Docker/scripts/entrypoint
+++ b/extra/Docker/scripts/entrypoint
@@ -6,8 +6,9 @@
 [ -z $NGINX_DEFAULT_PORT ] && export NGINX_DEFAULT_PORT=80
 [ -z $NGINX_APP_NAME ] && export NGINX_APP_NAME=pastefile
 [ -z $UWSGI_SOCK ] && export UWSGI_SOCK=/tmp/uwsgi.sock
+[ -z $MAX_FILE_SIZE ] && export MAX_FILE_SIZE=1G
 
 envsubst '$NGINX_WORKER_PROCESSES $NGINX_WORKER_CONNECTIONS $NGINX_KEEPALIVE_TIMEOUT' < /opt/pastefile/nginx.conf.template > /etc/nginx/nginx.conf
-envsubst '$NGINX_DEFAULT_PORT $NGINX_APP_NAME $UWSGI_SOCK' < /opt/pastefile/vhost.conf.template > /etc/nginx/conf.d/pastefile.conf
- uwsgi -s $UWSGI_SOCK -w pastefile.app:app --chdir /var/www/pastefile --uid 33 --gid 33 --env PASTEFILE_SETTINGS=/etc/pastefile.cfg --enable-threads --daemonize=/tmp/uwsgi-pastefile.log
-nginx -g "daemon off;"
+envsubst '$NGINX_DEFAULT_PORT $NGINX_APP_NAME $UWSGI_SOCK $MAX_FILE_SIZE' < /opt/pastefile/vhost.conf.template > /etc/nginx/conf.d/pastefile.conf
+nginx
+exec uwsgi -s $UWSGI_SOCK -w pastefile.app:app --chdir /var/www/pastefile --uid 33 --gid 33 --env PASTEFILE_SETTINGS=/etc/pastefile.cfg --enable-threads


### PR DESCRIPTION
- Add file max size variable in the nginx configuration.
- Display nginx logs on stdout
- Swap nginx and uswgi in the entrypoint.
